### PR TITLE
Add ESP8266 doorbell sensor device

### DIFF
--- a/DoorbellSensor/DoorbellSensor.ino
+++ b/DoorbellSensor/DoorbellSensor.ino
@@ -1,0 +1,72 @@
+#include <ESP8266WiFi.h>
+
+extern "C" {
+#include "user_interface.h"
+}
+
+// configure WiFi credentials and bridge IP
+const char* ssid = "WiFi name";        // replace with your wifi name
+const char* password = "WiFi password"; // replace with your wifi password
+const char* bridgeIp = "192.168.xxx.xxx"; //replace with the hue emulator device ip
+
+// static ip configuration to reduce boot time
+IPAddress strip_ip ( 192,  168,   0,  98); // choose an unique IP address
+IPAddress gateway_ip ( 192,  168,   0,   1);
+IPAddress subnet_mask(255, 255, 255,   0);
+
+#define doorbell_pin 4 // optocoupler output connected to this GPIO
+
+uint8_t mac[6];
+
+void goingToSleep() {
+  yield();
+  delay(100);
+  ESP.deepSleep(0);
+  yield();
+  delay(100);
+}
+
+String macToStr(const uint8_t* mac) {
+  String result;
+  for (int i = 0; i < 6; ++i) {
+    result += String(mac[i], 16);
+    if (i < 5) {
+      result += ':';
+    }
+  }
+  return result;
+}
+
+void sendDoorbellEvent() {
+  WiFiClient client;
+  String url = "/switch?mac=" + macToStr(mac) + "&button=1";
+  client.connect(bridgeIp, 80);
+  client.print(String("GET ") + url + " HTTP/1.1\r\n" +
+               "Host: " + bridgeIp + "\r\n" +
+               "Connection: close\r\n\r\n");
+}
+
+void setup() {
+  pinMode(doorbell_pin, INPUT);
+  pinMode(2, OUTPUT);
+  digitalWrite(2, HIGH);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  WiFi.config(strip_ip, gateway_ip, subnet_mask);
+  WiFi.macAddress(mac);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(50);
+  }
+
+  if (digitalRead(doorbell_pin) == HIGH) {
+    sendDoorbellEvent();
+  }
+
+  goingToSleep();
+}
+
+void loop() {
+}
+

--- a/DoorbellSensor/README.md
+++ b/DoorbellSensor/README.md
@@ -1,0 +1,7 @@
+# Doorbell Sensor
+
+This device uses an optocoupler connected to the doorbell wires to trigger an ESP8266.
+The optocoupler output should be wired to GPIO4. When the doorbell is pressed, the
+sketch sends a notification to the diyHue bridge using an HTTP request.
+
+Configure the WiFi credentials and bridge IP inside the sketch before uploading.


### PR DESCRIPTION
## Summary
- add DoorbellSensor sketch to detect doorbell ring via optocoupler on GPIO4 and notify diyHue bridge
- document wiring and configuration in README

## Testing
- `g++ -fsyntax-only -x c++ -I/tmp -include /tmp/Arduino.h DoorbellSensor/DoorbellSensor.ino`


------
https://chatgpt.com/codex/tasks/task_e_688d8035aac083268e48a1653be3fe9c