### PR TITLE
Add doorbell sensor device

### DIFF
--- a/HueDoorbellSensor/HueDoorbellSensor.ino
+++ b/HueDoorbellSensor/HueDoorbellSensor.ino
@@ -1,0 +1,70 @@
+#include <ESP8266WiFi.h>
+
+// WiFi credentials
+const char* ssid = "WiFi name";       // replace with your wifi name
+const char* password = "WiFi password";   // replace with your wifi password
+
+// IP address of diyHue bridge/emulator
+const char* bridgeIp = "192.168.xxx.xxx"; // replace with the hue emulator device ip
+
+// GPIO where the optocoupler output is connected
+#define DOORBELL_PIN 5
+
+byte mac[6];
+int lastState = HIGH;
+
+String macToStr(const uint8_t* mac)
+{
+  String result;
+  for (int i = 0; i < 6; ++i) {
+    result += String(mac[i], 16);
+    if (i < 5) {
+      result += ':';
+    }
+  }
+  return result;
+}
+
+void sendHttpRequest()
+{
+  WiFiClient client;
+  String url = "/switch?mac=" + macToStr(mac) + "&button=1000";
+  client.connect(bridgeIp, 80);
+  client.print(String("GET ") + url + " HTTP/1.1\r\n" +
+               "Host: " + bridgeIp + "\r\n" +
+               "Connection: close\r\n\r\n");
+}
+
+void setup()
+{
+  pinMode(2, OUTPUT);
+  digitalWrite(2, HIGH);
+  pinMode(DOORBELL_PIN, INPUT_PULLUP);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  WiFi.macAddress(mac);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(50);
+  }
+
+  // register device
+  WiFiClient client;
+  String url = "/switch?devicetype=ZLLSwitch&mac=" + macToStr(mac);
+  client.connect(bridgeIp, 80);
+  client.print(String("GET ") + url + " HTTP/1.1\r\n" +
+               "Host: " + bridgeIp + "\r\n" +
+               "Connection: close\r\n\r\n");
+}
+
+void loop()
+{
+  int state = digitalRead(DOORBELL_PIN);
+  if (state == LOW && lastState == HIGH) {
+    sendHttpRequest();
+  }
+  lastState = state;
+  delay(50);
+}
+

--- a/HueDoorbellSensor/README.md
+++ b/HueDoorbellSensor/README.md
@@ -1,0 +1,13 @@
+## Hue Doorbell Sensor
+
+This device monitors the input of a doorbell through an optocoupler connected to an ESP8266.
+When the doorbell rings the optocoupler pulls the I/O line low and a request is sent to the diyHue bridge.
+
+### Wiring
+- Doorbell wires -> optocoupler -> GPIO5 (D1) on the ESP8266
+- Optocoupler output uses the internal pull‑up resistor
+
+### Behaviour
+Pressing the doorbell triggers a single HTTP request to the configured diyHue bridge using the `ZLLSwitch` device type.
+
+Configure WiFi credentials, bridge IP and adjust the pin if required in `HueDoorbellSensor.ino` before uploading.


### PR DESCRIPTION
## Summary
- add HueDoorbellSensor module for monitoring doorbell input through optocoupler
- register device as `ZLLSwitch` and send button event when doorbell is pressed

## Testing
- `arduino-cli compile HueDoorbellSensor/HueDoorbellSensor.ino` *(fails: command not found)*
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688d8035aac083268e48a1653be3fe9c